### PR TITLE
Better image expiry

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -42,7 +42,7 @@ export default function Sidebar() {
                 <div className='mt-3 flex items-center rounded-full py-1 px-3 border-2 w-fit border-[#828282]'>
                   <div
                     className={`${
-                      (item.status == 'processed' ||
+                      (item.status == 'ready' ||
                         item.status === 'completed') &&
                       'bg-green-600'
                     } ${

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -1,13 +1,13 @@
 import { ref, orderByChild, limitToLast, query, equalTo, startAt, limitToFirst, onValue, get } from 'firebase/database';
 import { useList, useListVals } from 'react-firebase-hooks/database';
 import React, { use, useEffect, useState } from 'react'
-import { queueRef } from '@lib/firebase';
+import { queueRef, completedRef } from '@lib/firebase';
 
-export function useItems({
+export function completedItems({
     limit = 6,
 }) {
     const latestRef = query(
-        queueRef,
+        completedRef,
         orderByChild('completed_at'),
         limitToLast(limit)
     );
@@ -16,7 +16,7 @@ export function useItems({
 }
 
 export function useRecentImages() {
-    const [items, loading, error] = useItems({ limit: 8 });
+    const [items, loading, error] = completedItems({ limit: 8 });
     const [images, setImages] = useState([]);
     useEffect(() => {
         if(items.length > 0) {
@@ -32,60 +32,21 @@ export function useRecentImages() {
 }
 
 export function useRecentQueue() {
-    const latestRef = query(
+    const [items, loading, error] = useListVals(query(
         queueRef,
         orderByChild('timestamp'),
-        limitToLast(6)
-    );
-    const [items, loading, error] = useListVals(latestRef);
-    const [reverseItems, setReverseItems] = useState([]);
-
-    useEffect(() => {
-        if (items.length > 0) {
-            setReverseItems(items.reverse());
-        }
-    }, [items]);
-    return [reverseItems, loading, error];
+        limitToFirst(6)
+    ));
+    return [items, loading, error];
 }
 
 export function useLatestItem() {
+    const [items, loading, error] = completedItems({ limit: 1 })
     const [item, setItem] = React.useState(null);
-    async function sync(params) {
-        const latestRef = query(
-            queueRef,
-            orderByChild('expiry_at'),
-            startAt(new Date().getTime()),
-            limitToFirst(1)
-        );
-
-        const snapshot = await get(latestRef);
-        const data = snapshot.val();
-        if (data != null)
-           { setItem(Object.values(data)[0])}
-        else {
-            const lastItemRef = query(
-                queueRef,
-                orderByChild('expiry_at'),
-                limitToLast(1)
-            );
-    
-            const lastItemsnapshot = await get(lastItemRef);
-            const lastItemdata = lastItemsnapshot.val();
-            if (lastItemdata != null)
-            { setItem(Object.values(lastItemdata)[0])}
-        }
-    }
-
     useEffect(() => {
-        const interval = setInterval(() => {
-            // setCount(count + 1);
-            sync();
-        }, 1000);
-
-        return () => clearInterval(interval);
-    }, []);
-
-    const loading = item == null;
-    return [item, loading];
-
+        if (items.length > 0) {
+            setItem(items[0]);
+        }
+    }, [items]);
+    return [item, loading]
 }

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -34,7 +34,7 @@ export function useRecentImages() {
 export function useRecentQueue() {
     const [items, loading, error] = useListVals(query(
         queueRef,
-        orderByChild('timestamp'),
+        orderByChild('created_at'),
         limitToFirst(6)
     ));
     return [items, loading, error];

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -3,7 +3,7 @@ import { useList, useListVals } from 'react-firebase-hooks/database';
 import React, { use, useEffect, useState } from 'react'
 import { queueRef, completedRef } from '@lib/firebase';
 
-export function completedItems({
+export function useCompletedItems({
     limit = 6,
 }) {
     const latestRef = query(
@@ -16,7 +16,7 @@ export function completedItems({
 }
 
 export function useRecentImages() {
-    const [items, loading, error] = completedItems({ limit: 8 });
+    const [items, loading, error] = useCompletedItems({ limit: 8 });
     const [images, setImages] = useState([]);
     useEffect(() => {
         if(items.length > 0) {
@@ -41,7 +41,7 @@ export function useRecentQueue() {
 }
 
 export function useLatestItem() {
-    const [items, loading, error] = completedItems({ limit: 1 })
+    const [items, loading, error] = useCompletedItems({ limit: 1 })
     const [item, setItem] = React.useState(null);
     useEffect(() => {
         if (items.length > 0) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -9,6 +9,6 @@ export function insertPrompt(data) {
     set(newPostRef, {
         ...data,
         status: 'pending',
-        timestamp: serverTimestamp()
+        created_at: serverTimestamp()
     });
 }

--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -23,6 +23,6 @@ const firebaseApp = initializeApp(firebaseConfig);
 // const analytics = getAnalytics(app);
 
 export const database = getDatabase(firebaseApp);
-export const queueRef = ref(database, '_queue');
-export const completedRef = ref(database, '_completed');
+export const queueRef = ref(database, 'queue');
+export const completedRef = ref(database, 'completed');
 export default firebaseApp;

--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -24,4 +24,5 @@ const firebaseApp = initializeApp(firebaseConfig);
 
 export const database = getDatabase(firebaseApp);
 export const queueRef = ref(database, '_queue');
+export const completedRef = ref(database, '_completed');
 export default firebaseApp;

--- a/server/index.js
+++ b/server/index.js
@@ -17,9 +17,9 @@ admin.initializeApp({
 });
 
 var db = admin.database();
-var queueRef = db.ref("_queue");
-var readyRef = db.ref("_ready")
-var completedRef = db.ref("_completed")
+var queueRef = db.ref("queue");
+var readyRef = db.ref("ready")
+var completedRef = db.ref("completed")
 
 // Read all values where status is pending
 queueRef.orderByChild("status")

--- a/server/index.js
+++ b/server/index.js
@@ -17,52 +17,55 @@ admin.initializeApp({
 });
 
 var db = admin.database();
-var ref = db.ref("_queue");
+var queueRef = db.ref("_queue");
+var readyRef = db.ref("_ready")
+var completedRef = db.ref("_completed")
 
 // Read all values where status is pending
-ref.orderByChild("status")
+queueRef.orderByChild("status")
     .equalTo("pending")
     .on("value", function (snapshot) {
         // Set status to processing and initiate generation
         snapshot.forEach(async function (childSnapshot) {
             childSnapshot.ref.update({ status: "processing" });
             const url = await generateImage(childSnapshot.val().text);
-            moveToProcessed(childSnapshot,url)
+            childSnapshot.ref.update({ status: "ready" });
+            moveToReady(childSnapshot,url)
         });
     });
 
-async function moveToProcessed(newEntry,url){
-    await newEntry.ref.update({
-        status: "processed",
+async function moveToReady(newEntry,url){
+    await readyRef.push({
+        ...newEntry.val(),
+        keyInQueue: newEntry.key,
+        status: "ready",
         url,
-        completed_at: admin.database.ServerValue.TIMESTAMP
+        completed_at: Date.now() // Do not use server timestamp here, because that will cause on("value") to be called multiple times for the same entry
     })
-    const snapshot = await newEntry.ref.once('value')
-    updateExpiryAt(snapshot)
 }
-
-async function updateExpiryAt(newEntry) {
-    const newEntryCompletedTime = newEntry.val().completed_at;
-  
-    const snapshot = await ref.orderByChild("expiry_at")
-      .startAt(newEntryCompletedTime)
-      .limitToLast(1)
-      .once('value');
-  
-    if (!snapshot.exists()) {
-      await newEntry.ref.update({
-        expiry_at: newEntryCompletedTime + TIME_TO_SHOW_AN_IMAGE_MS
-      });
-      return;
-    }
-  
-    snapshot.forEach(async function (childSnapshot) {
-      const latestExpiryAt = childSnapshot.val().expiry_at;
-      await newEntry.ref.update({
-        expiry_at: latestExpiryAt + TIME_TO_SHOW_AN_IMAGE_MS
-      });
+    
+readyRef.orderByChild("completed_at")
+    .limitToFirst(1)
+    .on("value",function(snapshot){
+        if(!snapshot.exists()) return;
+        snapshot.forEach(function(childSnapshot){
+            moveToCompleted(childSnapshot)
+            setTimeout(function(){
+                childSnapshot.ref.remove()
+            },TIME_TO_SHOW_AN_IMAGE_MS)
+        })
     });
-  }
+
+async function moveToCompleted(newEntry){
+    const refToEntryInQueue = newEntry.val().keyInQueue
+    if(refToEntryInQueue){
+        queueRef.child(refToEntryInQueue).remove()
+    }
+    completedRef.push({
+        ...newEntry.val(),
+        status: "completed",
+    })
+}
 
 async function generateImage(prompt) {
     const modelParameters = {


### PR DESCRIPTION
Moved to a queue based system for managing timeout
Removed all usages of expiry_at
There'll be three lists of items -> "queue", "ready", "completed"

queue -> contains "pending", "processing" and "ready" items.
ready -> contains items currently waiting to be shown (server manages the 15s timeouts in this queue and removes the entries one a time
completed -> contains items for which images are generated. Latest item in this list is to be shown as the current image.